### PR TITLE
automate darwin-amd64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
 
       # We need api 1.41 to override platform
       - name: Install docker stable
@@ -39,6 +39,18 @@ jobs:
         working-directory: fetchenvoy
         run: |
           go run . ${{steps.tagName.outputs.tag}}
+
+      - name: Install getenvoy
+        run: |
+          curl -L https://getenvoy.io/cli | bash -s -- -b ~/
+
+      - name: Run getenvoy
+        working-directory: fetchenvoy
+        run: |
+          TAG=${{steps.tagName.outputs.tag}}
+          VERSION=${TAG//v/}
+          ~/getenvoy fetch standard:${VERSION}/darwin
+          cp ~/.getenvoy/builds/standard/${VERSION}/darwin/bin/envoy envoy-darwin-amd64
 
       - name: Upload binaries to release
         working-directory: fetchenvoy


### PR DESCRIPTION
Try to consolidate our upstream source for envoy by automatically getting darwin-amd64 via `getenvoy` in the same workflow as other platform builds.

Also bump go to `1.16`