### PR TITLE
Use consistent tag detection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Get tag name
         id: tagName
         run: |
-          TAG=$(git describe --tags --exact-match)
+          TAG=${GITHUB_REF##*/}
           echo ::set-output name=tag::${TAG}
       - name: checkout envoy
         uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
       - name: Get tag name
         id: tagName
         run: |
-          TAG=$(git describe --tags --exact-match)
+          TAG=${GITHUB_REF##*/}
           echo ::set-output name=tag::${TAG}
 
       - name: Run fetchenvoy


### PR DESCRIPTION
We're not checking out this repo during the Darwin build, so we need to check ${GITHUB_REF} for our release tag name.