### PR TITLE
add release build options to darwin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ steps.tagName.outputs.tag }}
       - name: build
         run: |
-          bazelisk build --curses=no --show_task_finish --verbose_failures --action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin:$PATH --test_output=all //source/exe:envoy-static
+          bazelisk build --curses=no --show_task_finish --verbose_failures --action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin:$PATH --test_output=all -c "opt" //source/exe:envoy-static --config=sizeopt
           mv bazel-bin/source/exe/envoy-static envoy-darwin-amd64
       - name: Upload binaries to release
         env:


### PR DESCRIPTION
The envoy release binaries are built with specific config options specified.  Ensure we're using those for darwin.