### PR TITLE
fetch binary built for oldest macOS version

### DIFF
--- a/scripts/fetch-envoy
+++ b/scripts/fetch-envoy
@@ -45,27 +45,19 @@ extract_envoy_from_homebrew() {
     _version="${_envoy_tag:1}"
     _tmp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t 'tmp_dir')"
 
-    if [ "$_arch" == "arm64" ]; then
-        (
-            cd "$_tmp_dir"
-            oras pull "ghcr.io/homebrew/core/envoy:${_version}" --platform "darwin/arm64"
-            tar --extract \
-                --file envoy--*.bottle.tar.gz \
-                --directory . \
-                --strip-components=3 \
-                "envoy/${_version}/bin/envoy"
-        )
-    else
-        (
-            cd "$_tmp_dir"
-            oras pull ghcr.io/homebrew/core/envoy:"${_version}" --platform "darwin/amd64"
-            tar --extract \
-                --file envoy--*.bottle.tar.gz \
-                --directory . \
-                --strip-components=3 \
-                "envoy/${_version}/bin/envoy"
-        )
-    fi
+    (
+        cd "$_tmp_dir"
+        _digest=$(oras manifest fetch "ghcr.io/homebrew/core/envoy:${_version}" |
+            jq -r ".manifests |
+                map(select(.platform | contains({os: \"$_os\", architecture: \"$_arch\"}))) |
+                min_by(.platform[\"os.version\"]) | .digest")
+        oras pull "ghcr.io/homebrew/core/envoy:${_version}@${_digest}"
+        tar --extract \
+            --file envoy--*.bottle.tar.gz \
+            --directory . \
+            --strip-components=3 \
+            "envoy/${_version}/bin/envoy"
+    )
     mv -f "$_tmp_dir/envoy" "$_bin_dir/envoy-$_os-$_arch"
 }
 


### PR DESCRIPTION
It looks like Homebrew builds binaries for the three latest versions of macOS (for both amd64 and arm64). Currently it looks like the fetch-envoy script may end up downloading any one of the three available binaries for a specific architecture.

Let's update this script so that it will choose the binary built for the oldest available macOS version, as that should provide the widest compatibility. We can do this by first fetching the multi-platform manifest, filtering by OS and architecture, and then finding the minimum OS version.

(Note that the OS version is a text string like "macOS 12.6". Comparing these strings may not be totally correct in general, but I think it should give a correct result while the major version still has two digits.)